### PR TITLE
feat: add AWS AppSync fingerprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ graphw00f currently attempts to discover the following GraphQL engines:
 * Tartiflette - Python
 * Dgraph - JavaScript
 * Directus - TypeScript
+* AWS AppSync
 
 # GraphQL Technologies Defence Matrices
 Each fingerprinted technology (e.g. Graphene, Ariadne, ...) has an associated document ([example for graphene](https://github.com/dolevf/graphw00f/blob/main/docs/graphene.md)) which covers the security defence mechanisms the specific technology supports to give a better idea how the implementation may be attacked.

--- a/graphw00f/helpers.py
+++ b/graphw00f/helpers.py
@@ -73,6 +73,12 @@ def get_engines():
       'ref':'https://github.com/dolevf/graphw00f/blob/main/docs/apollo.md',
       'technology':['JavaScript', 'Node.js', 'TypeScript']
     },
+    'aws-appsync':{
+      'name':'Aws AppSync',
+      'url':'https://aws.amazon.com/appsync',
+      'ref':'https://aws.amazon.com/appsync',
+      'technology':[],
+    },
     'graphene':{
       'name':'Graphene',
       'url':'https://graphene-python.org',

--- a/graphw00f/lib.py
+++ b/graphw00f/lib.py
@@ -47,6 +47,8 @@ class GRAPHW00F:
       return 'ariadne'
     elif self.engine_apollo():
       return 'apollo'
+    elif self.engine_awsappsync():
+        return 'aws-appsync'
     elif self.engine_hasura():
       return 'hasura'
     elif self.engine_wpgraphql():
@@ -114,6 +116,11 @@ class GRAPHW00F:
       return True
 
     return False
+
+  def engine_awsappsync(self):
+      query = 'query @skip { __typename }'
+      response = self.graph_query(self.url, payload=query)
+      return error_contains(response, 'MisplacedDirective')
 
   def engine_graphene(self):
     query = '''aaa'''


### PR DESCRIPTION
Hello @dolevf,

I work at [Escape](https://escape.tech/), a platform that helps developers find and fix the security flaws of their GraphQL endpoint, directly inside the CI-CD pipeline.

Therefore, I am glad to contribute to your repository to make GraphQL safer, by providing a detection for Aws AppSync which is largely used in the ecosystem.

Hope you will find it useful.

Btw, checkout our free tool, [graphql.security](https://graphql.security/) to run dozens of GraphQL security tests for free, in ten seconds and without any sign-in. Also, results are private and not stored.