### PR TITLE
Added --proxy and --burp options.

### DIFF
--- a/graphw00f/lib.py
+++ b/graphw00f/lib.py
@@ -14,12 +14,14 @@ class GRAPHW00F:
   def __init__(self, headers,
                      cookies,
                      timeout,
+                     proxies,
                      follow_redirects=False):
     self.url = 'http://example.com'
     self.cookies = cookies
     self.headers = headers
     self.follow_redirects = follow_redirects,
     self.timeout = timeout
+    self.proxies = proxies
 
   def check(self, url):
     query = '''
@@ -109,6 +111,7 @@ class GRAPHW00F:
                              verify=False,
                              allow_redirects=self.follow_redirects,
                              timeout=self.timeout,
+                             proxies=self.proxies,
                              json={operation:payload})
       return response.json()
     except:

--- a/main.py
+++ b/main.py
@@ -32,6 +32,7 @@ def main():
     parser.add_option('-t', '--target', dest='url', help='target url with the path')
     parser.add_option('-f', '--fingerprint', dest='fingerprint', default=False, action='store_true', help='fingerprint mode')
     parser.add_option('-d', '--detect', dest='detect', default=False, action='store_true', help='detect mode')
+    parser.add_option('-p', '--proxy', dest='proxy', default=None, help='HTTP(S) proxy URL in the form http://user:pass@host:port')
     parser.add_option('-T', '--timeout', dest='timeout', default=10, help='Request timeout in seconds')
     parser.add_option('-o', '--output-file', dest='output_file',
                             help='Output results to a file (CSV)', default=None)
@@ -67,13 +68,21 @@ def main():
       parser.print_help()
       sys.exit(1)
 
+    proxies = None
+    if options.proxy:
+      proxies = {
+          'http': options.proxy,
+          'https': options.proxy
+      }
+
     if not isinstance(options.timeout, int):
       options.timeout = 10
 
     g = GRAPHW00F(follow_redirects=options.followredirect,
                   headers=conf.HEADERS if not options.useragent else {**conf.HEADERS, **{'User-Agent': options.useragent}},
                   cookies=conf.COOKIES,
-                  timeout=options.timeout)
+                  timeout=options.timeout,
+                  proxies=proxies)
     url = options.url
 
     url_scheme = urlparse(url).scheme

--- a/version.py
+++ b/version.py
@@ -1,1 +1,1 @@
-VERSION = '1.1.8'
+VERSION = '1.1.9'


### PR DESCRIPTION
Added support for explicit proxy specification through `requests`' built in proxy support. As a result, you don't need to rely on system proxies or set environment variables :)

Using `--proxy` specifies an explicit proxy location.
Using `--burp` uses the default Burp Suite proxy: 127.0.0.1:8080. 
