### PR TITLE
Bug Fix: Run app without custom headers

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ def main():
     parser.add_option('-l', '--list', dest='list', action='store_true', default=False,
                             help='List all GraphQL technologies graphw00f is able to detect')
     parser.add_option('-u', '--user-agent', dest='useragent', default=None, help='Custom user-agent to use (overrides the one from headers configuration)')
-    parser.add_option('-H', '--header', dest='header', action='append', default=None, help='Custom headers to send (e.g. "Authorization: Bearer ey...").')
+    parser.add_option('-H', '--header', dest='header', action='append', default=[], help='Custom headers to send (e.g. "Authorization: Bearer ey...").')
     parser.add_option('-w', '--wordlist', dest='wordlist', default=False, help='Path to a list of custom GraphQL endpoints')
     parser.add_option('--version', '-v', dest='version', action='store_true', default=False,
                             help='Print out the current version and exit.')


### PR DESCRIPTION
#27 added support for custom headers, but it breaks the app if there are no custom headers provided.

```
parser.add_option('-H', '--header', dest='header', action='append', default=None, help='Custom headers to send (e.g. "Authorization: Bearer ey...").')
```
Default value is set to `None`, later on we iterate over headers:
```
for header in options.header:
```

Causing the crash:
```
> python main.py -d -f -t https://www.target.com
Traceback (most recent call last):
  File "C:\Users\windows\Documents\graphw00f\main.py", line 172, in <module>
    main()
  File "C:\Users\windows\Documents\graphw00f\main.py", line 87, in main
    for header in options.header:
TypeError: 'NoneType' object is not iterable
```

This PR just changes the default value to empty list