### PR TITLE
Fix typo in Hasura engine query

### DIFF
--- a/graphw00f/lib.py
+++ b/graphw00f/lib.py
@@ -174,7 +174,7 @@ class GRAPHW00F:
         return True
     query = '''
      query {
-       aa
+       aaa
       }
     '''
     response = self.graph_query(self.url, payload=query)


### PR DESCRIPTION
Fix typo in query so that it yields the expected error message.

Double-checked by testing it at https://learn-graphql.demo.hasura.io/console.